### PR TITLE
change 'id' argument of 'employeeByID' GraphQL query to be non nullable

### DIFF
--- a/docker/echo_server.js
+++ b/docker/echo_server.js
@@ -71,7 +71,7 @@ schema {
 }
 
 type Query {
-  employeeByID(id: String): Employee
+  employeeByID(id: String!): Employee
 }
 `;
 


### PR DESCRIPTION
Small change to the `employeeByID` query, making `id` a non-nullable argument since an optional since it would make little sense to be optional in a real-world API